### PR TITLE
Update 2-Creating-A-Bitstream.ipynb

### DIFF
--- a/notebooks/tutorial/2-Creating-A-Bitstream.ipynb
+++ b/notebooks/tutorial/2-Creating-A-Bitstream.ipynb
@@ -39,14 +39,14 @@
     "    cp -r ~/RISC-V-On-PYNQ/ip/gold/picorv32_tutorial/ ~/RISC-V-On-PYNQ/ip/\n",
     "```\n",
     "\n",
-    "To skip the second step, **[Creating a RISC-V Bitstream for the PYNQ-Z1](2-Creating-A-Bitstream.ipynb#Creating-a-RISC-V-Bitstream-for-the-PYNQ-Z1)**, copy `picorv32.tcl` and `picorv32.bit` from ` <Path-To-RISC-V-On-PYNQ>/riscvonpynq/picorv32/tutorial/gold/` to ` <Path-To-RISC-V-On-PYNQ>/riscvonpynq/picorv32/tutorial/`. For example, on our Linux host machine we would run the following command in a BASH shell to skip the step \n",
+    "To skip the second step, **[Creating a RISC-V Bitstream for the PYNQ-Z1](2-Creating-A-Bitstream.ipynb#Creating-a-RISC-V-Bitstream-for-the-PYNQ-Z1)**, copy `tutorial.tcl` and `tutorial.bit` from ` <Path-To-RISC-V-On-PYNQ>/riscvonpynq/picorv32/tut/gold/` to ` <Path-To-RISC-V-On-PYNQ>/riscvonpynq/picorv32/tut/`. For example, on our Linux host machine we would run the following command in a BASH shell to skip the step \n",
     "\n",
     "If your repository is located in your home directory, this can be accomplished with the following commands:\n",
     "\n",
     "```bash\n",
-    "    cp ~/RISC-V-On-PYNQ/riscvonpynq/picorv32/tut/gold/picorv32.tcl ~/RISC-V-On-PYNQ/riscvonpynq/picorv32/tut/\n",
+    "    cp ~/RISC-V-On-PYNQ/riscvonpynq/picorv32/tut/gold/tutorial.tcl ~/RISC-V-On-PYNQ/riscvonpynq/picorv32/tut/\n",
     "\n",
-    "    cp ~/RISC-V-On-PYNQ/riscvonpynq/picorv32/tut/gold/picorv32.bit ~/RISC-V-On-PYNQ/riscvonpynq/picorv32/tut/\n",
+    "    cp ~/RISC-V-On-PYNQ/riscvonpynq/picorv32/tut/gold/tutorial.bit ~/RISC-V-On-PYNQ/riscvonpynq/picorv32/tut/\n",
     "```"
    ]
   },


### PR DESCRIPTION
For the part 'skipping steps in this notebook', under 'to skip the second step', 

1. Changed the name of folder from tutorial to tut 
2. Changed the name of the files from picorv32.tcl and picorv32.bit to tutorial.tcl and tutorial.bit 